### PR TITLE
Add py.typed file (PEP 561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
+include = ["kink/py.typed"]
+
 # Requirements
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
[PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) says "Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing". Tools like mypy fail to recognize the type annotations in this package unless a `py.typed` file is present, repro below:

```dockerfile
FROM python:3.9

WORKDIR /app
RUN echo "from kink import di" > file.py
RUN pip3 install kink mypy

RUN mypy file.py || true

RUN python -c 'import kink; from pathlib import Path; (Path(kink.__file__).parent / "py.typed").touch()'
RUN mypy file.py
```

Results in:

```
...

Step 5/7 : RUN mypy file.py || true
 ---> Running in 6fa0e34be763
file.py:1: error: Skipping analyzing "kink": found module but no type hints or library stubs
file.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
Removing intermediate container 6fa0e34be763
 ---> e568387aeb98
Step 6/7 : RUN python -c 'import kink; from pathlib import Path; (Path(kink.__file__).parent / "py.typed").touch()'
 ---> Running in 2679dcfb01f9
Removing intermediate container 2679dcfb01f9
 ---> 855e2b8807e5
Step 7/7 : RUN mypy file.py
 ---> Running in e19b80f372dc
Success: no issues found in 1 source file

...
```