### PR TITLE
Don't resolve passed parameters

### DIFF
--- a/kink/inject.py
+++ b/kink/inject.py
@@ -123,7 +123,10 @@ def _decorate(binding: Dict[str, Any], service: ServiceDefinition, container: Co
         if len(passed_kwargs) == len(parameters_name):
             return passed_kwargs
 
-        resolved_kwargs = _resolve_function_kwargs(binding, parameters_name, parameters, container)
+        # do not resolve for passed kwargs and args
+        parameters_name_to_resolve = tuple(parameters_name - passed_kwargs.keys())
+
+        resolved_kwargs = _resolve_function_kwargs(binding, parameters_name_to_resolve, parameters, container)
 
         all_kwargs = {**resolved_kwargs, **passed_kwargs}
 

--- a/tests/test_issue_passed_parameters.py
+++ b/tests/test_issue_passed_parameters.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from kink import di, inject
+
+def test_do_not_resolve_passed_kwargs() -> None:
+    di["name"] = "Bob"
+    @inject
+    class ExpensiveObject:
+        def __init__(self, name: str):
+            self.name = name
+            raise Exception("Constructing expensive object")
+
+    @inject
+    def greet(namer: ExpensiveObject, greeting: str = "Hello %s") -> str:
+        return greeting % namer.name
+
+    mock_expensive_object = MagicMock(spec=ExpensiveObject)
+    mock_expensive_object.name = "Bill"
+
+    assert greet(namer=mock_expensive_object) == "Hello Bill"
+
+def test_do_not_resolve_passed_args() -> None:
+    di["name"] = "Bob"
+    @inject
+    class ExpensiveObject:
+        def __init__(self, name: str):
+            self.name = name
+            raise Exception("Constructing expensive object")
+
+    @inject
+    def greet(namer: ExpensiveObject, greeting: str = "Hello %s") -> str:
+        return greeting % namer.name
+
+    mock_expensive_object = MagicMock(spec=ExpensiveObject)
+    mock_expensive_object.name = "Bill"
+
+    assert greet(mock_expensive_object) == "Hello Bill"


### PR DESCRIPTION
When parameters are partially specified by the caller, parameter resolution happens for all parameters, including the passed in parameters. This can cause some unexpected behavior if the construction of the parameter is expensive or has side-effects.

I ran into this issue when introducing Kink into a complex project with a large unit test suit. The unit tests would pass in mock objects, but Kink would try to resolve them anyway, sometimes resulting in unexpected side-effects and errors. 

This change will skip parameter resolution for parameters that were passed in by the caller.

** Maintainers - I am new to the Kink codebase. If there is a better way/place to make this change, I am happy to take feedback and see this change through.