### PR TITLE
Add build-system to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ httpx = "^0.26.0"
 black = "^24.2.0"
 mypy = "^1.8.0"
 
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I use NixOs to build CI/CD. And for that I need to have build-system in pyproject.toml. It won't affect the code at all.